### PR TITLE
feat: add @warp-ds and @borealis prefixes to packages lists

### DIFF
--- a/application.json
+++ b/application.json
@@ -14,7 +14,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "pin",
@@ -28,7 +30,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["after 6pm on sunday"],
       "rangeStrategy": "pin",
@@ -49,7 +53,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "rangeStrategy": "pin",
       "automerge": true,

--- a/sub-level-module.json
+++ b/sub-level-module.json
@@ -9,7 +9,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "pin",
@@ -23,7 +25,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["after 6pm on sunday"],
       "rangeStrategy": "pin",
@@ -39,7 +43,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "rangeStrategy": "pin",
       "automerge": true,

--- a/top-level-module.json
+++ b/top-level-module.json
@@ -9,7 +9,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["before 6am on the first day of the month"],
       "rangeStrategy": "pin",
@@ -23,7 +25,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "schedule": ["after 6pm on sunday"],
       "rangeStrategy": "pin",
@@ -44,7 +48,9 @@
         "@podium",
         "@eik",
         "@fabric-ds",
-        "@metrics"
+        "@metrics",
+        "@warp-ds",
+        "@borealis"
       ],
       "rangeStrategy": "pin",
       "automerge": true,


### PR DESCRIPTION
This PR makes sure updates in @warp-ds and `@borealis` modules are also picked up by Renovate. Those modules are internal and maintained by [Warp Design System](https://github.com/orgs/warp-ds/teams/warp-core-team) and Web Platform team respectively.