### PR TITLE
fix: support default pnpm catalogs

### DIFF
--- a/application.json
+++ b/application.json
@@ -24,7 +24,7 @@
     },
     {
       "groupName": "External Dependencies",
-      "matchDepTypes": ["dependencies""],
+      "matchDepTypes": ["dependencies"],
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",

--- a/application.json
+++ b/application.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "Dev Dependencies",
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": ["devDependencies", "pnpm.catalog.default"],
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -24,7 +24,7 @@
     },
     {
       "groupName": "External Dependencies",
-      "matchDepTypes": ["dependencies"],
+      "matchDepTypes": ["dependencies", "pnpm.catalog.default"],
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",

--- a/application.json
+++ b/application.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "groupName": "Dev Dependencies",
-      "matchDepTypes": ["devDependencies", "pnpm.catalog.default"],
+      "matchDepTypes": ["devDependencies"],
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -24,7 +24,7 @@
     },
     {
       "groupName": "External Dependencies",
-      "matchDepTypes": ["dependencies", "pnpm.catalog.default"],
+      "matchDepTypes": ["dependencies""],
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -57,6 +57,16 @@
         "@warp-ds",
         "@borealis"
       ],
+      "rangeStrategy": "pin",
+      "automerge": true,
+      "major": {
+        "automerge": false
+      }
+    },
+    {
+      "groupName": "Default version catalog dependencies",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "schedule": ["after 6pm on sunday"],
       "rangeStrategy": "pin",
       "automerge": true,
       "major": {


### PR DESCRIPTION
Better than having no grouping 🤷‍♂️ 

We recently migrated to version catalog and lost the dev and non-dev dependency groupings (which is understandable). With version catalog we should probably group by catalog, but it is nice to have a sane default.