### PR TITLE
fix: specify minimumReleaseAge

### DIFF
--- a/application.json
+++ b/application.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "lockFileMaintenance": {
     "enabled": true,
@@ -9,6 +10,7 @@
     {
       "groupName": "Dev Dependencies",
       "matchDepTypes": ["devDependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -27,6 +29,7 @@
     {
       "groupName": "External Dependencies",
       "matchDepTypes": ["dependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -71,6 +74,7 @@
     },
     {
       "groupName": "Default version catalog dependencies",
+      "minimumReleaseAge": "1 day",
       "matchDepTypes": ["pnpm.catalog.default"],
       "schedule": ["after 6pm on sunday"],
       "rangeStrategy": "pin",

--- a/js.json
+++ b/js.json
@@ -1,10 +1,12 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>finn-no/renovate-presets:base",
     "group:linters",
     "group:postcss",
     ":widenPeerDependencies"
   ],
+  "minimumReleaseAge": "1 day",
   "dependencyDashboard": true,
   "lockFileMaintenance": {
     "enabled": true,

--- a/sub-level-module.json
+++ b/sub-level-module.json
@@ -1,9 +1,11 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "packageRules": [
     {
       "groupName": "Dev Dependencies",
       "matchDepTypes": ["devDependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -20,6 +22,7 @@
     {
       "groupName": "External Dependencies",
       "matchDepTypes": ["dependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",

--- a/top-level-module.json
+++ b/top-level-module.json
@@ -1,9 +1,11 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "packageRules": [
     {
       "groupName": "Dev Dependencies",
       "matchDepTypes": ["devDependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",
@@ -20,6 +22,7 @@
     {
       "groupName": "External Dependencies",
       "matchDepTypes": ["dependencies"],
+      "minimumReleaseAge": "1 day",
       "excludePackagePrefixes": [
         "@finn-no",
         "@podium",


### PR DESCRIPTION
The schema doesn't indicate that minimumReleaseAge is valid in packageRules, but the docs and example say this should work.

- https://docs.renovatebot.com/key-concepts/minimum-release-age/
- https://github.com/renovatebot/github-action/blob/ba515daaf07a82d9861dbf23f39b279a9fb6de9e/example/renovate-config.json#L26